### PR TITLE
[feature/detail-api] 상세 페이지 추가 구현

### DIFF
--- a/src/hooks/useExperience.ts
+++ b/src/hooks/useExperience.ts
@@ -57,30 +57,30 @@ export interface ReviewResponse {
   reviews: Review[];
 }
 
-export const useExperienceDetail = (teamId: string, activityId: number) => {
+export const useExperienceDetail = (activityId: number) => {
   return useQuery<ExperienceResponse>({
-    queryKey: ['experienceDetail', teamId, activityId],
-    queryFn: () => activitiesService.getActivityId({ teamId, activityId }),
+    queryKey: ['experienceDetail', activityId],
+    queryFn: () => activitiesService.getActivityId({ activityId }),
   });
 };
 
-export const useReserveExperience = (teamId: string, activityId: number) => {
+export const useReserveExperience = (activityId: number) => {
   return useMutation({
     mutationFn: (payload: ReserveExperiencePayload) =>
-      activitiesService.createReservations({ teamId, activityId }, payload),
+      activitiesService.createReservations({ activityId }, payload),
   });
 };
 
-export const useDeleteExperience = (teamId: string, activityId: number) => {
+export const useDeleteExperience = (activityId: number) => {
   return useMutation({
-    mutationFn: () => myActivitiesService.deleteActivity({ teamId, activityId }),
+    mutationFn: () => myActivitiesService.deleteActivity({ activityId }),
   });
 };
 
-export const useExperienceReviews = (teamId: string, activityId: number, page = 1, size = 3) => {
+export const useExperienceReviews = (activityId: number, page = 1, size = 3) => {
   return useQuery<ReviewResponse>({
-    queryKey: ['experienceReviews', teamId, activityId, page, size],
-    queryFn: () => activitiesService.getReviews({ teamId, activityId, page, size }),
+    queryKey: ['experienceReviews', activityId, page, size],
+    queryFn: () => activitiesService.getReviews({ activityId, page, size }),
     placeholderData: keepPreviousData,
   });
 };

--- a/src/hooks/useExperience.ts
+++ b/src/hooks/useExperience.ts
@@ -1,11 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
-import {
-  getExperienceDetail,
-  getExperienceReviews,
-  reserveExperience,
-  deleteExperience,
-} from '@/pages/detail/example/example';
+import { activitiesService } from '@/apis/activities';
+import { myActivitiesService } from '@/apis/myActivities';
 
 export interface SubImage {
   id: number;
@@ -19,7 +15,7 @@ export interface Schedule {
   endTime: string;
 }
 
-export interface ExperienceDetailProps {
+export interface ExperienceResponse {
   id: number;
   userId: number;
   title: string;
@@ -60,29 +56,31 @@ export interface ReviewResponse {
   totalCount: number;
   reviews: Review[];
 }
+
 export const useExperienceDetail = (teamId: string, activityId: number) => {
-  return useQuery<ExperienceDetailProps>({
+  return useQuery<ExperienceResponse>({
     queryKey: ['experienceDetail', teamId, activityId],
-    queryFn: () => getExperienceDetail(teamId, activityId),
+    queryFn: () => activitiesService.getActivityId({ teamId, activityId }),
   });
 };
 
 export const useReserveExperience = (teamId: string, activityId: number) => {
   return useMutation({
     mutationFn: (payload: ReserveExperiencePayload) =>
-      reserveExperience(teamId, activityId, payload),
+      activitiesService.createReservations({ teamId, activityId }, payload),
   });
 };
 
 export const useDeleteExperience = (teamId: string, activityId: number) => {
   return useMutation({
-    mutationFn: () => deleteExperience(teamId, activityId),
+    mutationFn: () => myActivitiesService.deleteActivity({ teamId, activityId }),
   });
 };
 
 export const useExperienceReviews = (teamId: string, activityId: number, page = 1, size = 3) => {
   return useQuery<ReviewResponse>({
     queryKey: ['experienceReviews', teamId, activityId, page, size],
-    queryFn: () => getExperienceReviews(teamId, activityId, page, size),
+    queryFn: () => activitiesService.getReviews({ teamId, activityId, page, size }),
+    placeholderData: keepPreviousData,
   });
 };

--- a/src/pages/detail/DetailPage.module.css
+++ b/src/pages/detail/DetailPage.module.css
@@ -1,3 +1,7 @@
+.experienceDetail {
+  margin: 3rem 2.4rem 7.5rem;
+}
+
 .wrapper {
   padding-bottom: 30rem;
   display: flex;
@@ -330,6 +334,11 @@
 }
 
 @media (min-width: 1024px) {
+  .experienceDetail {
+    margin: 8.8rem auto 18rem;
+    max-width: 120rem;
+  }
+
   .wrapper {
     display: grid;
     grid-template-areas:
@@ -373,6 +382,7 @@
     width: auto;
     left: auto;
     bottom: auto;
+    z-index: 0;
     grid-area: calendar;
   }
 

--- a/src/pages/detail/DetailPage.tsx
+++ b/src/pages/detail/DetailPage.tsx
@@ -13,6 +13,8 @@ import Pagination from '@/components/Pagination/Pagination';
 import Modal from '@/components/modal/modal';
 import DetailSkeleton from './components/loading/DetailSkeleton';
 
+import { useAuthStore } from '@/stores/useAuthStore';
+
 import {
   useExperienceDetail,
   useReserveExperience,
@@ -36,6 +38,10 @@ const DetailPage = () => {
 
   const [searchParams] = useSearchParams();
   const currentPage = Number(searchParams.get('page')) || 1;
+
+  const userId = useAuthStore(state => state.userId);
+
+  const KAKAO_MAP_KEY = import.meta.env.VITE_KAKAO_MAP_KEY;
 
   const {
     data: experience,
@@ -104,7 +110,7 @@ const DetailPage = () => {
     } else {
       if (!document.querySelector(`script[src*="dapi.kakao.com"]`)) {
         const script = document.createElement('script');
-        script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=6e287159105f0af608f766ff304b9d17&libraries=services&autoload=false`;
+        script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_MAP_KEY}&libraries=services&autoload=false`;
         script.onload = () => {
           if (window.kakao?.maps?.load) {
             window.kakao.maps.load(loadMap);
@@ -150,7 +156,7 @@ const DetailPage = () => {
           <div className={styles.category}>{experience.category}</div>
           <div className={styles.titleRow}>
             <h3 className={styles.title}>{experience.title}</h3>
-            {true && (
+            {userId === experience.userId && (
               <div className={styles.menu}>
                 <IconMore
                   width={28}
@@ -223,7 +229,7 @@ const DetailPage = () => {
           </div>
         </section>
         <section className={styles.calendarWrapper}>
-          <div className={false ? styles.invisibleBox : ''}>
+          <div className={userId === experience.userId ? styles.invisibleBox : ''}>
             <Reservation
               price={experience.price}
               schedules={experience.schedules}

--- a/src/pages/detail/DetailPage.tsx
+++ b/src/pages/detail/DetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 
 import styles from './DetailPage.module.css';
 
@@ -11,6 +11,7 @@ import Reservation from '@/components/reservation/Reservation';
 import ReviewCard from '@/pages/detail/components/ReviewCard';
 import Pagination from '@/components/Pagination/Pagination';
 import Modal from '@/components/modal/modal';
+import DetailSkeleton from './components/loading/DetailSkeleton';
 
 import {
   useExperienceDetail,
@@ -29,10 +30,12 @@ const DetailPage = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  // TODO: 하드코딩된 값, 추후 동적 값으로 교체 필요
   const teamId = '14-5';
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+
+  const [searchParams] = useSearchParams();
+  const currentPage = Number(searchParams.get('page')) || 1;
 
   const {
     data: experience,
@@ -43,42 +46,30 @@ const DetailPage = () => {
     data: reviews,
     isLoading: isReviewLoading,
     isError: isReviewError,
-  } = useExperienceReviews(teamId, Number(id));
+  } = useExperienceReviews(teamId, Number(id), currentPage, 3);
 
-  const { mutateAsync: reserveExperience } = useReserveExperience(teamId, Number(id));
-  const { mutateAsync: deleteExperience } = useDeleteExperience(teamId, Number(id));
+  const { mutate: reserveExperience } = useReserveExperience(teamId, Number(id));
+  const { mutate: deleteExperience } = useDeleteExperience(teamId, Number(id));
 
-  const handleReserve = async ({
-    scheduleId,
-    headCount,
-  }: {
-    scheduleId: number;
-    headCount: number;
-  }) => {
-    try {
-      const response = await reserveExperience({ scheduleId, headCount });
-      console.log('예약 성공:', response);
-      setIsModalOpen(true);
-    } catch (e: unknown) {
-      if (e instanceof Error) {
-        console.error('예약 실패:', e.message);
-      } else {
-        console.error('알 수 없는 에러:', e);
+  const handleReserve = ({ scheduleId, headCount }: { scheduleId: number; headCount: number }) => {
+    reserveExperience(
+      { scheduleId, headCount },
+      {
+        onSuccess: response => {
+          console.log('예약 성공:', response);
+          setIsModalOpen(true);
+        },
       }
-    }
+    );
   };
 
-  const handleDelete = async () => {
-    try {
-      const response = await deleteExperience();
-      console.log('삭제 성공:', response);
-    } catch (e: unknown) {
-      if (e instanceof Error) {
-        console.error('삭제 실패:', e.message);
-      } else {
-        console.error('알 수 없는 에러:', e);
-      }
-    }
+  const handleDelete = () => {
+    deleteExperience(undefined, {
+      onSuccess: response => {
+        console.log('삭제 성공:', response);
+        navigate('/');
+      },
+    });
   };
 
   const onLoadKakaoMap = (address: string) => {
@@ -133,13 +124,14 @@ const DetailPage = () => {
     }
   }, [experience]);
 
-  if (isDetailLoading || isReviewLoading) return <p>로딩 중...</p>;
-  if (isDetailError || isReviewError) return <p>데이터 로드 중 오류가 발생했습니다.</p>;
-  if (!experience) return <p>데이터 없음</p>;
-  if (!reviews) return <p>리뷰 없음</p>;
+  if (isDetailLoading || isReviewLoading || !experience || !reviews) {
+    return <DetailSkeleton />;
+  }
+  if (isDetailError) throw new Error('체험 상세 정보를 불러오는 중 에러 발생');
+  if (isReviewError) throw new Error('리뷰를 불러오는 중 에러 발생');
 
   return (
-    <>
+    <div className={styles.experienceDetail}>
       <div className={styles.wrapper}>
         <div className={styles.images}>
           <img src={experience.bannerImageUrl} className={styles.mainImage} />
@@ -245,7 +237,7 @@ const DetailPage = () => {
           <p className={styles.modalText}>예약이 완료되었습니다.</p>
         </Modal>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/detail/DetailPage.tsx
+++ b/src/pages/detail/DetailPage.tsx
@@ -32,7 +32,6 @@ const DetailPage = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const teamId = '14-5';
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
@@ -47,15 +46,15 @@ const DetailPage = () => {
     data: experience,
     isLoading: isDetailLoading,
     isError: isDetailError,
-  } = useExperienceDetail(teamId, Number(id));
+  } = useExperienceDetail(Number(id));
   const {
     data: reviews,
     isLoading: isReviewLoading,
     isError: isReviewError,
-  } = useExperienceReviews(teamId, Number(id), currentPage, 3);
+  } = useExperienceReviews(Number(id), currentPage, 3);
 
-  const { mutate: reserveExperience } = useReserveExperience(teamId, Number(id));
-  const { mutate: deleteExperience } = useDeleteExperience(teamId, Number(id));
+  const { mutate: reserveExperience } = useReserveExperience(Number(id));
+  const { mutate: deleteExperience } = useDeleteExperience(Number(id));
 
   const handleReserve = ({ scheduleId, headCount }: { scheduleId: number; headCount: number }) => {
     reserveExperience(

--- a/src/pages/detail/components/loading/DetailSkeleton.module.css
+++ b/src/pages/detail/components/loading/DetailSkeleton.module.css
@@ -1,0 +1,125 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin: 3rem 2.4rem 7.5rem;
+  padding: 0;
+}
+
+.imageBlock {
+  display: flex;
+  flex-direction: row;
+  gap: 1.2rem;
+  height: 24.5rem;
+}
+
+.mainImage,
+.subImage {
+  height: 100%;
+  border-radius: 2.4rem;
+  flex: 1;
+}
+
+.subImages {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.card,
+.description {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.cardLine {
+  width: 100%;
+  height: 1.6rem;
+  border-radius: 0.6rem;
+}
+
+.cardTitle {
+  width: 60%;
+  height: 2.4rem;
+  border-radius: 0.6rem;
+}
+
+.cardMeta {
+  width: 100%;
+  height: 3.2rem;
+  border-radius: 0.6rem;
+}
+
+.textLine {
+  height: 1.4rem;
+  width: 100%;
+  border-radius: 0.4rem;
+}
+
+.map {
+  height: 18rem;
+  border-radius: 1.6rem;
+}
+
+@media (min-width: 1024px) {
+  .wrapper {
+    display: grid;
+    grid-template-areas:
+      'images card'
+      'images calendar'
+      'description calendar'
+      'map calendar'
+      'map .';
+    column-gap: 4rem;
+    row-gap: 4rem;
+    padding: 0rem 4rem;
+    max-width: 120rem;
+    margin: 8.8rem auto 18rem;
+  }
+
+  .imageBlock {
+    grid-area: images;
+    height: 40rem;
+  }
+
+  .map {
+    grid-area: map;
+    height: 45rem;
+    border-radius: 2.4rem;
+  }
+
+  .card {
+    grid-area: card;
+  }
+
+  .description {
+    grid-area: description;
+  }
+
+  .calendar {
+    grid-area: calendar;
+    position: static;
+    height: 30rem;
+    width: auto;
+    z-index: 0;
+  }
+}
+
+.skeleton {
+  background-color: #e0e0e0;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    background-color: #f3f4f6;
+  }
+  50% {
+    background-color: #e0e0e0;
+  }
+  100% {
+    background-color: #f3f4f6;
+  }
+}

--- a/src/pages/detail/components/loading/DetailSkeleton.tsx
+++ b/src/pages/detail/components/loading/DetailSkeleton.tsx
@@ -1,0 +1,32 @@
+import styles from './DetailSkeleton.module.css';
+
+const DetailSkeleton = () => {
+  return (
+    <div className={styles.wrapper}>
+      <div className={`${styles.imageBlock}`}>
+        <div className={`${styles.mainImage} ${styles.skeleton}`} />
+        <div className={styles.subImages}>
+          <div className={`${styles.subImage} ${styles.skeleton}`} />
+          <div className={`${styles.subImage} ${styles.skeleton}`} />
+        </div>
+      </div>
+
+      <div className={styles.card}>
+        <div className={`${styles.cardLine} ${styles.skeleton}`} />
+        <div className={`${styles.cardTitle} ${styles.skeleton}`} />
+        <div className={`${styles.cardMeta} ${styles.skeleton}`} />
+      </div>
+
+      <div className={styles.description}>
+        <div className={`${styles.textLine} ${styles.skeleton}`} />
+        <div className={`${styles.textLine} ${styles.skeleton}`} />
+        <div className={`${styles.textLine} ${styles.skeleton}`} />
+      </div>
+
+      <div className={`${styles.map} ${styles.skeleton}`} />
+      <div className={`${styles.calendar} ${styles.skeleton}`} />
+    </div>
+  );
+};
+
+export default DetailSkeleton;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -16,12 +16,9 @@ import AddExperiences from './pages/add-experiences/AddExperiences';
 import EditExperiences from './pages/edit-experiences/EditExperiences';
 import ReservationStatus from './pages/reservation-status/ReservationStatus';
 
-
 import OAuthKakaoCallback from './pages/oauthkakaocallback/OAuthKakaoCallback';
 
-
 import LoadingUI from './pages/my-experiences/components/loading/Loading';
-
 
 const router = createBrowserRouter([
   {
@@ -31,7 +28,11 @@ const router = createBrowserRouter([
       { path: '/my-profile', element: <MyProfilePage /> },
       {
         path: 'detail/:id',
-        element: <DetailPage />,
+        element: (
+          <ErrorBoundary FallbackComponent={ErrorUI}>
+            <DetailPage />
+          </ErrorBoundary>
+        ),
       },
       {
         path: '/reservation-list',

--- a/src/types/api/activitiesType.ts
+++ b/src/types/api/activitiesType.ts
@@ -52,7 +52,7 @@ export interface CreateActivityResponse extends ActivityBase {
 
 /*GET activityId, 체험 상세 조회*/
 export interface GetActivityIdParams {
-  teamId: string;
+  teamId?: string;
   activityId: number;
 }
 
@@ -73,7 +73,7 @@ export type GetAvailableScheduleResponse = ActivityScheduleWithTime[];
 
 /*GET reviews, 체험 리뷰 조회*/
 export interface GetReviewsParams {
-  teamId: string;
+  teamId?: string;
   activityId: number;
   page?: number;
   size?: number;
@@ -97,7 +97,7 @@ export interface GetReviewsResponse {
 
 /*POST reservations, 체험 예약 신청*/
 export interface CreateReservationParams {
-  teamId: string;
+  teamId?: string;
   activityId: number;
 }
 

--- a/src/types/api/myActivitiesType.ts
+++ b/src/types/api/myActivitiesType.ts
@@ -110,7 +110,7 @@ export interface UpdateReservationResponse extends ReservationDetail {
 
 /*DELETE activityId, 내 체험 삭제*/
 export interface DeleteActivityParams {
-  teamId: string;
+  teamId?: string;
   activityId: number;
 }
 


### PR DESCRIPTION
## 📝 이슈
Closes #57 
<!-- 관련된 이슈 번호가 있다면 적어주세요. -->

---

## ✅ 작업 내역

<!-- 구현한 내용을 요약해 주세요. -->
### 추가 구현 
 - [x] 내가 만든 체험인 경우만 오른쪽 상단에 케밥 버튼이 나타나도록 하세요. 
 - [x] 내가 만든 체험인 경우 예약 카드가 보이지 않도록 하세요.
 - [x] 예약 가능한 시간을 선택하고 참여 인원수를 골라서 '예약하기' 버튼을 클릭하면 “예약이 완료되었습니다.” 모달창이 나타나도록 하세요.
- [x] 공통 api 연결
- [x] 체험 리뷰 조회 Pagination에 따른 refetch
- [x] DetailPage 스켈레톤 생성
- [x] error boundary 적용
### 스타일 수정
- [x] PC 일때 reservation 컴포넌트가 gnb 위로 올라가는 스타일 수정 
### 오류
- [x] 지도 미표시 오류 해결
---

## 📸 스크린샷 (Optional)

| 기능 | 스크린샷                                     |
| ---- | -------------------------------------------- |
| 예시 | ![image](https://example.com/screenshot.png) |

---

## 🔖 PR 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향 없는 변경 (오타, 탭 사이즈, 변수명 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가 또는 테스트 리팩토링
- [ ] 빌드 또는 패키지 매니저 설정 수정
- [ ] 파일/폴더명 수정
- [ ] 파일/폴더 삭제
- [ ] 파일/폴더 추가

---

## ⚠️ 추가적으로 설명할 내용
Suspense를 적용하면 페이지네이션 과정에서 쿼리 파라미터가 변경될 때마다 로딩 UI(fallback)가 반복적으로 나타날 것 같아서 useQuery와 isLoading을 활용한 명시적인 로딩 처리 방식이 더 적합하다고 판단했는데 Suspense를 사용하지 않는다면, 에러 처리를 Error Boundary보다 페이지 내에서 직접 처리하는 방식이 더 나을까요??
